### PR TITLE
Fix Dragonscale General

### DIFF
--- a/source/Grove/CardsLibrary/DragonscaleGeneral.cs
+++ b/source/Grove/CardsLibrary/DragonscaleGeneral.cs
@@ -31,6 +31,7 @@
             trg => trg.MustBeTargetable = false);
 
           p.TargetingRule(new EffectOrCostRankBy(rank: c => -c.Score, controlledBy: ControlledBy.SpellOwner));
+          p.TriggerOnlyIfOwningCardIsInPlay = true;
         });
     }
   }


### PR DESCRIPTION
Fix Dragonscale General's triggered ability to only activate when in play.

Closes #13 